### PR TITLE
feat(TuneLabelInput): add sublabel to component

### DIFF
--- a/src/components/TuneLabelInput.story.vue
+++ b/src/components/TuneLabelInput.story.vue
@@ -4,6 +4,11 @@ import TuneLabelInput from './TuneLabelInput.vue';
 
 <template>
   <Story>
-    <TuneLabelInput hint="I'm a hint"> Label </TuneLabelInput>
+    <TuneLabelInput
+      hint="I'm a hint"
+      sublabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod."
+    >
+      Label
+    </TuneLabelInput>
   </Story>
 </template>

--- a/src/components/TuneLabelInput.vue
+++ b/src/components/TuneLabelInput.vue
@@ -7,8 +7,13 @@ defineProps<{
 </script>
 
 <template>
-  <div class="tune-label mb-[2px] flex items-center gap-1">
-    <slot />
-    <TuneIconHint :hint="hint" />
+  <div class="tune-label-container flex flex-col">
+    <div class="tune-label mb-[2px] flex items-center gap-1">
+      <slot />
+      <TuneIconHint :hint="hint" />
+    </div>
+    <div v-if="$slots.sublabel" class="tune-sublabel text-sm text-skin-text opacity-60">
+      <slot name="sublabel" />
+    </div>
   </div>
 </template>

--- a/src/components/TuneLabelInput.vue
+++ b/src/components/TuneLabelInput.vue
@@ -3,6 +3,7 @@ import TuneIconHint from './TuneIconHint.vue';
 
 defineProps<{
   hint?: string;
+  sublabel?: string;
 }>();
 </script>
 
@@ -12,8 +13,8 @@ defineProps<{
       <slot />
       <TuneIconHint :hint="hint" />
     </div>
-    <div v-if="$slots.sublabel" class="tune-sublabel text-sm text-skin-text opacity-60">
-      <slot name="sublabel" />
+    <div v-if="sublabel" class="tune-sublabel text-sm text-skin-text opacity-60">
+      {{ sublabel }}
     </div>
   </div>
 </template>

--- a/src/components/TuneLabelInput.vue
+++ b/src/components/TuneLabelInput.vue
@@ -9,7 +9,7 @@ defineProps<{
 
 <template>
   <div class="tune-label-container flex flex-col">
-    <div class="tune-label mb-[2px] flex items-center gap-1">
+    <div class="tune-label flex items-center gap-1">
       <slot />
       <TuneIconHint :hint="hint" />
     </div>

--- a/src/components/TuneLabelInput.vue
+++ b/src/components/TuneLabelInput.vue
@@ -13,7 +13,7 @@ defineProps<{
       <slot />
       <TuneIconHint :hint="hint" />
     </div>
-    <div v-if="sublabel" class="tune-sublabel text-sm text-skin-text opacity-60">
+    <div v-if="sublabel" class="tune-sublabel">
       {{ sublabel }}
     </div>
   </div>

--- a/src/components/TuneSwitch.story.vue
+++ b/src/components/TuneSwitch.story.vue
@@ -7,6 +7,11 @@ const input = ref(false);
 
 <template>
   <Story>
-    <TuneSwitch v-model="input" label="Switch me" hint="I'm a switch" />
+    <TuneSwitch
+      v-model="input"
+      label="Switch me"
+      hint="I'm a switch"
+      sublabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod."
+    />
   </Story>
 </template>

--- a/src/components/TuneSwitch.vue
+++ b/src/components/TuneSwitch.vue
@@ -2,11 +2,18 @@
 import { Switch } from '@headlessui/vue';
 import TuneLabelInput from './TuneLabelInput.vue';
 
+type Definition = {
+  title: string;
+  description: string;
+  sublabel: string;
+};
+
 defineProps<{
   modelValue: boolean;
   label?: string;
+  sublabel?: string;
   hint?: string;
-  definition?: any;
+  definition?: Partial<Definition>;
   disabled?: boolean;
 }>();
 
@@ -14,7 +21,10 @@ const emit = defineEmits(['update:modelValue']);
 </script>
 
 <template>
-  <div class="flex items-center space-x-2 pr-2 pt-1">
+  <div
+    class="flex space-x-2 pr-2 pt-1"
+    :class="sublabel || definition?.sublabel ? 'items-start' : 'items-center'"
+  >
     <Switch
       :model-value="modelValue"
       :class="[
@@ -26,7 +36,7 @@ const emit = defineEmits(['update:modelValue']);
       @update:model-value="value => emit('update:modelValue', value)"
     >
       <span v-if="label || definition?.title" class="sr-only">
-        {{ label || definition.title }}
+        {{ label || definition?.title }}
       </span>
       <span
         :class="[
@@ -68,6 +78,9 @@ const emit = defineEmits(['update:modelValue']);
     </Switch>
     <TuneLabelInput v-if="label || definition?.title" :hint="hint || definition?.description">
       {{ label || definition?.title }}
+      <template v-if="sublabel || definition?.sublabel" #sublabel>
+        {{ sublabel || definition?.sublabel }}
+      </template>
     </TuneLabelInput>
   </div>
 </template>

--- a/src/components/TuneSwitch.vue
+++ b/src/components/TuneSwitch.vue
@@ -76,11 +76,12 @@ const emit = defineEmits(['update:modelValue']);
         </span>
       </span>
     </Switch>
-    <TuneLabelInput v-if="label || definition?.title" :hint="hint || definition?.description">
+    <TuneLabelInput
+      v-if="label || definition?.title"
+      :hint="hint || definition?.description"
+      :sublabel="sublabel || definition?.sublabel"
+    >
       {{ label || definition?.title }}
-      <template v-if="sublabel || definition?.sublabel" #sublabel>
-        {{ sublabel || definition?.sublabel }}
-      </template>
     </TuneLabelInput>
   </div>
 </template>

--- a/src/style.scss
+++ b/src/style.scss
@@ -136,6 +136,10 @@ body {
   @apply font-sans text-skin-text;
 }
 
+.tune-sublabel {
+  @apply font-sans text-sm text-skin-text opacity-60;
+}
+
 .tune-icon-hint {
   @apply text-sm hover:text-skin-link;
 }


### PR DESCRIPTION
This PR adds a sublabel to TuneLabelInput. It allows making different input components more flexible

<img width="394" alt="Screenshot 2023-05-24 at 15 08 36" src="https://github.com/snapshot-labs/tune/assets/7693369/efd3757a-91c6-4f91-ba72-11bb8add4c65">

If the sublabel is not passed to the named slot `sublabel` then all related HTML will be hidden